### PR TITLE
medium-header.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -80,6 +80,7 @@ var cnames_active = {
     , "lujaw": "lujaw.github.io"
     , "matthias-schuetz": "matthias-schuetz.github.io"
     , "maxnachlinger": "maxnachlinger.github.io"
+    , "medium-header": "danielfeelfine.github.io/medium-header"
     , "mfitzpatrick79": "mfitzpatrick79.github.io"
     , "mikeya": "mikeya.github.io"
     , "mithril": "lhorie.github.io/mithril"


### PR DESCRIPTION
Provide access for [medium-header](http://danielfeelfine.github.io/medium-header/) as [medium-header.js.org](http://medium-header.js.org).

Thanks!