### PR TITLE
freemarker.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -58,6 +58,7 @@ var cnames_active = {
     , "festercluck": "festercluck.github.io"
     , "finder": "applait.github.io/finderjs"
     , "flowchart": "adrai.github.io/flowchart.js"
+    , "freemarker": "ijse.github.io/freemarker.js"
     , "frzr": "pakastin.github.io/frzr"
     , "ghoullier": "ghoullier.github.io"
     , "goodseller": "goodseller.github.io"


### PR DESCRIPTION
http://ijse.github.io/freemarker.js/

It is an node module which makes [Freemarker](http://freemarker.org/) available for node.js with FMPP.