### PR TITLE
on.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -156,4 +156,5 @@ var cnames_active = {
     , "zodiac": "indus.github.io/Zodiac"
     , "zombie": "assaf.github.io/zombie"
     , "rahul": "rahulsukla.github.io/rahul"
+    , "on": "clayendisk.github.io/on.js"
 }


### PR DESCRIPTION
I'd actually like to point "on.js.org" to the github project itself, "github.com/clayendisk/on.js" -- Should I put that instead?