### PR TITLE
jstools.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -81,6 +81,7 @@ var cnames_active = {
     , "jjlc": "k-yak.github.io/JJLC"
     , "jodytate": "jodytate.github.io"
     , "json-schema-faker": "pateketrueke.github.io/json-schema-faker"
+    , "jstools": "jstools.github.io"
     , "labelauty": "fntneves.github.io/jquery-labelauty"
     , "laubstein": "laubstein.github.io"
     , "leandro": "leandrowd.github.io"


### PR DESCRIPTION
I've not added js.org logo yet because uses http instead of https.