### PR TITLE
elf.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -59,6 +59,7 @@ var cnames_active = {
     , "date": "matthewmueller.github.io/date"
     , "delegacias-fortaleza": "juliosampaio.github.io/delegacias-fortaleza"
     , "dns": "js-org.github.io/dns"
+    , "elf": "elfjs.github.io"
     , "elliot": "elliotboney.github.io"
     , "emulisp": "grahack.github.io/EmuLisp"
     , "euclid": "anandthakker.github.io/euclid"


### PR DESCRIPTION
elf.js library for now using `elfjs.com`, but after the expiration of the domain I'd like to change it to `elf.js.org`.